### PR TITLE
Add assertions and allow handlers to be relative to basedir.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,20 +6,36 @@ var assert = require('assert'),
     path = require('path'),
     caller = require('caller'),
     utils = require('./utils'),
-    url = require('url'),
     buildroutes = require('./buildroutes');
 
+
 function swaggerize(options) {
-    var routes, schema, subSchemas;
+    var schemas;
 
     assert.ok(thing.isObject(options), 'Expected options to be an object.');
     assert.ok(thing.isObject(options.api), 'Expected an api definition.');
-    assert.ok(!options.schemas || thing.isArray(options.schemas), 'Expected schemas option to be an array.');
+
+    if ('basedir' in options) {
+        assert.ok(thing.isString(options.basedir), 'Expected basedir to be a string.');
+        assert.ok(options.basedir.length, 'Expected basedir to be a non-empty string.');
+    }
+
+    if ('schemas' in options) {
+        assert.ok(thing.isArray(options.schemas), 'Expected schemas option to be an array.');
+    }
+
+    if ('handlers' in options) {
+        assert.ok(thing.isString(options.handlers), 'Expected handlers to be a string.');
+        assert.ok(options.handlers.length, 'Expected handlers to be a non-empty string.');
+    }
+
 
     options.basedir = options.basedir || path.dirname(caller());
 
-    if (options.schemas) {
-        subSchemas = {};
+
+    // Map and validate API against schemas
+    if (thing.isArray(options.schemas)) {
+        schemas = {};
 
         options.schemas.forEach(function (schema) {
             assert.ok(thing.isObject(schema), 'Expected schema option to be an object.');
@@ -31,25 +47,24 @@ function swaggerize(options) {
                 schema.schema = require(path.resolve(options.basedir, schema.schema));
             }
 
-            subSchemas[schema.name] = schema.schema;
+            schemas[schema.name] = schema.schema;
         });
-
-        options.schemas = subSchemas;
     }
 
-    schema = enjoi(require(path.join(__dirname, 'schema/swagger-spec/schemas/v2.0/schema.json')), subSchemas);
-
-    schema.validate(options.api, function (error) {
+    enjoi(require('./schema/swagger-spec/schemas/v2.0/schema.json'), schemas).validate(options.api, function (error) {
         assert.ifError(error);
     });
 
-    if (thing.isString(options.handlers) || !options.handlers) {
-        options.handlers = options.handlers && path.resolve(options.handlers) || path.join(options.basedir, 'handlers');
+
+    // Resolve path to handlers
+    options.handlers = options.handlers || './handlers';
+    if (path.resolve(options.handlers) !== options.handlers) {
+        // Relative path, so resolve to basedir
+        options.handlers = path.join(options.basedir, options.handlers);
     }
 
-    routes = buildroutes(options);
-
-    return routes;
+    return buildroutes(options);
 }
+
 
 module.exports = swaggerize;

--- a/test/test-swaggerize.js
+++ b/test/test-swaggerize.js
@@ -121,3 +121,53 @@ test('additional schemas', function (t) {
     });
 
 });
+
+
+test('handlers', function (t) {
+
+    t.test('absolute path', function(t) {
+        t.plan(1);
+
+        t.doesNotThrow(function () {
+            swaggerize({
+                api: require('./fixtures/defs/pets.json'),
+                handlers: path.join(__dirname, './fixtures/handlers')
+            });
+        });
+    });
+
+    t.test('relative path', function(t) {
+        t.plan(1);
+
+        t.doesNotThrow(function () {
+            swaggerize({
+                api: require('./fixtures/defs/pets.json'),
+                handlers: './fixtures/handlers'
+            });
+        });
+    });
+
+    t.test('relative path with basedir', function(t) {
+        t.plan(1);
+
+        t.doesNotThrow(function () {
+            swaggerize({
+                api: require('./fixtures/defs/pets.json'),
+                basedir: path.join(__dirname, './fixtures'),
+                handlers: './handlers'
+            });
+        });
+    });
+
+    t.test('basedir with no handlers property', function(t) {
+        t.plan(1);
+
+        t.doesNotThrow(function () {
+            swaggerize({
+                api: require('./fixtures/defs/pets.json'),
+                basedir: path.join(__dirname, './fixtures')
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Fixes #15. Add more validation/assertions and allow handlers property to depend on basedir for resolution.
