### PR TITLE
Use result after validation

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -62,7 +62,8 @@ module.exports = function validator(options) {
                       return original.replace('value', parameter.name);
                     }
 
-                    schema.validate(data, function (error) {
+                    schema.validate(data, function (error, result) {
+
                         if (error) {
 
                             error.message = parameterNameReplacement(error.message);
@@ -76,7 +77,7 @@ module.exports = function validator(options) {
                             return;
                         }
 
-                        callback(null, data);
+                        callback(null, result || data);
                     });
                 }
             };

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -215,6 +215,24 @@ test('validation', function (t) {
         });
     });
 
+  t.test('input ignore extra value', function(t) {
+    t.plan(4);
+
+    var v = validator.make(require('./fixtures/defs/pets.json').definitions.Pet);
+
+    v.schema._settings = {
+      allowUnknown: true,
+      stripUnknown: true
+    };
+
+    v.validate({ id: 1, name: 'fluffy', extra: 'foo'}, function(error, result) {
+        t.ok(!error, 'no error.');
+        t.ok(result.id === 1, 'Has id with value of 1')
+        t.ok(result.name === 'fluffy', 'Has name with value of "fluffy"')
+        t.ok(!result.extra, 'No extra properties')
+    });
+  });
+
 });
 
 


### PR DESCRIPTION
In some cases, passing additional options to the validator causes the
incoming data to be changed.

For example, adding the enjoi settings:

    allowUnknown: true
    stripUnknown: true

Will cause any incoming, unknown properties to be removed from the
object that is being validated.

This change ensures those results are used rather than the original,
pre-validated object.