### PR TITLE
Use parameters property of path items for validation

### DIFF
--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -25,7 +25,7 @@ function buildroutes(options) {
         var def = options.api.paths[path];
 
         utils.verbs.forEach(function (verb) {
-            var route, pathnames, operation;
+            var route, pathnames, operation, validators;
 
             operation = def[verb];
 
@@ -45,11 +45,21 @@ function buildroutes(options) {
                 produces: operation.produces || api.produces
             };
 
-            if (operation.parameters) {
-                operation.parameters.forEach(function (parameter) {
-                    route.validators.push(validator.make(parameter));
+            validators = {};
+
+            if (def.parameters) {
+                def.parameters.forEach(function (parameter) {
+                    validators[parameter.in + parameter.name] = parameter;
                 });
             }
+
+            if (operation.parameters) {
+                operation.parameters.forEach(function (parameter) {
+                    validators[parameter.in + parameter.name] = parameter;
+                });
+            }
+
+            route.validators = Object.keys(validators).map(function (k) { return validator.make(validators[k]); });
 
             pathnames = [];
 

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -172,6 +172,100 @@
                     }
                 }
             }
+        },
+        "/pets/{id}/items": {
+            "get": {
+                "description": "Returns all pet's items based on the pet ID supplied.",
+                "operationId": "findItemOfPet",
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "default": ["read"]
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "required": false,
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "item response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Item"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new item for pet.",
+                "operationId": "createItemForPet",
+                "security": [
+                    {
+                        "default": ["write"]
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "item",
+                        "in": "body",
+                        "description": "Item to add to the store",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Item"
+                        }
+                    },
+                    {
+                        "name": "date",
+                        "in": "header",
+                        "description": "Operation date",
+                        "required": true,
+                        "type": "string",
+                        "format": "dateTime"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "$ref": "#/definitions/Item"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {"$ref": "#/parameters/id"},
+                {
+                    "name": "date",
+                    "in": "header",
+                    "description": "Operation date",
+                    "required": false,
+                    "type": "string",
+                    "format": "dateTime"
+                }
+            ]
         }
     },
     "parameters": {
@@ -218,6 +312,26 @@
                     "type": "string"
                 },
                 "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "Item": {
+            "type": "object",
+            "required": [
+                "id",
+                "name",
+                "type"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/test/fixtures/handlers/pets/{id}/item.js
+++ b/test/fixtures/handlers/pets/{id}/item.js
@@ -1,0 +1,4 @@
+module.exports = {
+    get: function (req, res) {},
+    post: function (req, res) {}
+}

--- a/test/test-routebuilder.js
+++ b/test/test-routebuilder.js
@@ -57,14 +57,18 @@ test('routebuilder', function (t) {
                     $post: function () {},
                     '{id}': {
                         $get: function () {},
-                        $delete: function () {}
+                        $delete: function () {},
+                        'items': {
+                            $get: function () {},
+                            $post: function () {}
+                        }
                     }
                 }
             },
             schemaValidator: schemaValidator
         });
 
-        t.strictEqual(routes.length, 4, 'added 4 routes.');
+        t.strictEqual(routes.length, 6, 'added 6 routes.');
 
         routes.forEach(function (route) {
             t.ok(route.hasOwnProperty('method'), 'has method property.');
@@ -103,6 +107,19 @@ test('routebuilder', function (t) {
         }, function (error, newvalue) {
             t.ok(!error, 'validation passed.');
         });
+
+        t.end();
+    });
+
+    t.test('route validator merge', function(t) {
+        var route;
+        route = routes[5];
+
+        t.strictEqual(route.validators.length, 3, 'has 3 validators.');
+
+        var validator;
+        validator = route.validators.filter(function (validator) {return validator.parameter.name === 'date'}).shift();
+        t.ok(validator.parameter.required, 'override by operation.');
 
         t.end();
     });


### PR DESCRIPTION
Parameters property of Path Item Object should also be used for validation.
And it can be overridden by parameters property of operation object.

https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#pathItemObject