### PR TITLE
added custom 'file' type to validators.

### DIFF
--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -18,7 +18,6 @@ function buildroutes(options) {
     api = options.api;
     handlers = readhandlers(options.handlers);
     validator = validation(options);
-
     routes = [];
 
     Object.keys(api.paths).forEach(function (path) {
@@ -59,7 +58,7 @@ function buildroutes(options) {
                 });
             }
 
-            route.validators = Object.keys(validators).map(function (k) { return validator.make(validators[k]); });
+            route.validators = validator.makeAll(validators, route);
 
             pathnames = [];
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -7,9 +7,31 @@ var assert = require('assert'),
 
 
 module.exports = function validator(options) {
-    var schemas;
+    var schemas, types;
 
     schemas = {};
+    types = {
+        file: enjoi({
+            type: 'object',
+            properties: {
+                value: {
+                    type: 'string',
+                    minLength: 0,
+                    required: true
+                },
+                consumes: {
+                    type: 'string',
+                    pattern: /multipart\/form-data|application\/x-www-form-urlencoded/,
+                    required: true
+                },
+                in: {
+                    type: 'string',
+                    pattern: /formData/,
+                    required: true
+                }
+            }
+        })
+    }
 
     schemas['#'] = options.api;
 
@@ -23,14 +45,29 @@ module.exports = function validator(options) {
          * @param parameter
          * @returns {Function}
          */
-        make: function (parameter) {
-            var schema, coerce, template;
+        makeAll: function (validators, route) {
+            var self = this;
+
+            return Object.keys(validators).map(function (k) {
+                var parameter = validators[k];
+
+                return self.make(parameter, route.consumes);
+            });
+        },
+
+        /**
+         * Creates a parameter validator.
+         * @param parameter
+         * @returns {Function}
+         */
+        make: function (parameter, consumes) {
+            var schema, coerce, template, parameter;
 
             if (parameter.$ref) {
                 parameter = refresolver(schemas, parameter.$ref);
             }
 
-            coerce = coercion(parameter);
+            coerce = coercion(parameter, consumes);
 
             template = {
                 required: parameter.required,
@@ -42,11 +79,17 @@ module.exports = function validator(options) {
                 pattern: parameter.pattern
             };
 
-            if (parameter.in === 'body' && template.schema) {
-                schema = enjoi(template.schema, schemas);
+            if ((parameter.in === 'body' || parameter.in === 'formData') && template.schema) {
+                schema = enjoi(template.schema, {
+                    subSchemas: schemas,
+                    types: types
+                });
             }
             else {
-                schema = enjoi(template, schemas);
+                schema = enjoi(template, {
+                    subSchemas: schemas,
+                    types: types
+                });
             }
 
             if (parameter.required) {
@@ -58,7 +101,6 @@ module.exports = function validator(options) {
                 schema: schema,
                 validate: function validateParameter(data, callback) {
                     coerce && data && (data = coerce(data));
-
                     schema.validate(data, function (error, result) {
                         if (error) {
                             error.message = error.message.replace('value', parameter.name);
@@ -117,7 +159,7 @@ function refresolver(schemas, value) {
  * Coercion of doubles and longs are not supported in Javascript and strings should be used instead for 64bit numbers.
  * @param type
  */
-function coercion(parameter) {
+function coercion(parameter, consumes) {
     var fn;
 
     switch (parameter.type) {
@@ -159,6 +201,16 @@ function coercion(parameter) {
         case 'dateTime':
             fn = Date.parse;
             break;
+        case 'file': {
+            fn = function (data) {
+                return {
+                    value: data,
+                    consumes: consumes,
+                    in: parameter.in
+                };
+            }
+            break;
+        }
     }
 
     if (!fn && parameter.schema) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -31,7 +31,7 @@ module.exports = function validator(options) {
                 }
             }
         })
-    }
+    };
 
     schemas['#'] = options.api;
 
@@ -61,7 +61,7 @@ module.exports = function validator(options) {
          * @returns {Function}
          */
         make: function (parameter, consumes) {
-            var schema, coerce, template, parameter;
+            var schema, coerce, template;
 
             if (parameter.$ref) {
                 parameter = refresolver(schemas, parameter.$ref);
@@ -208,7 +208,7 @@ function coercion(parameter, consumes) {
                     consumes: consumes,
                     in: parameter.in
                 };
-            }
+            };
             break;
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swaggerize-routes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Trevor Livingston <trlivingston@paypal.com>",
   "description": "Swagger based route building.",
   "main": "./lib/index",
@@ -16,7 +16,7 @@
     "caller": "^0.0.1",
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",
-    "enjoi": "^0.2.0"
+    "enjoi": "^1.0.0"
   },
   "devDependencies": {
     "tape": "^2.4.2",

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -234,21 +234,43 @@ test('validation', function (t) {
         });
     });
 
-  t.test('input ignore extra value', function(t) {
-    t.plan(2);
+    t.test('input ignore extra value', function(t) {
+        t.plan(2);
 
-    var v = validator.make(require('./fixtures/defs/pets.json').definitions.Pet);
+        var v = validator.make(require('./fixtures/defs/pets.json').definitions.Pet);
 
-    v.schema._settings = {
-      allowUnknown: true,
-      stripUnknown: true
-    };
+        v.schema._settings = {
+          allowUnknown: true,
+          stripUnknown: true
+        };
 
-    v.validate({ id: 1, name: 'fluffy', extra: 'foo'}, function(error, result) {
-        t.ok(!error, 'no error.');
-        t.ok(!result.extra, 'No extra properties')
+        v.validate({ id: 1, name: 'fluffy', extra: 'foo'}, function(error, result) {
+            t.ok(!error, 'no error.');
+            t.ok(!result.extra, 'No extra properties')
+        });
     });
-  });
+
+    t.test('formData', function (t) {
+        t.plan(1);
+
+        validator.make({
+            name: 'upload',
+            type: 'file'
+        }, 'multipart/form-data').validate('data', function (error) {
+            t.ok(!error, 'no error.');
+        });
+    });
+
+    t.test('formData bad consumes', function (t) {
+        t.plan(1);
+
+        validator.make({
+            name: 'upload',
+            type: 'file'
+        }, 'application/json').validate('data', function (error) {
+            t.ok(error, 'error.');
+        });
+    });
 
 });
 


### PR DESCRIPTION
this is to workaround the swagger issue regarding the addition of the 'file' primitive.

see: https://github.com/krakenjs/swaggerize-express/issues/57
see: https://github.com/swagger-api/swagger-spec/issues/340
