### PR TITLE
Fix coerce for booleans

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -153,7 +153,9 @@ function coercion(parameter) {
             };
             break;
         case 'boolean':
-            fn = Boolean;
+            fn = function(data) {
+                return (data === 'true') || (data === '1');
+            };
             break;
         case 'date':
         case 'dateTime':

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -198,15 +198,33 @@ test('validation', function (t) {
         });
     });
 
-    t.test('input coerce to boolean (pass)', function (t) {
-        t.plan(1);
+    ['false', '0'].forEach(function(value) {
+        t.test('input coerce to boolean (pass) - value ' + value, function (t) {
+            t.plan(2);
 
-        validator.make({
-            name: 'id',
-            required: true,
-            type: 'boolean'
-        }).validate(1, function (error) {
-            t.ok(!error, 'no error.');
+            validator.make({
+                name: 'id',
+                required: true,
+                type: 'boolean'
+            }).validate(value, function (error, result) {
+                t.ok(!error, 'no error.');
+                t.equal(result, false);
+            });
+        });
+    });
+
+    ['true', '1'].forEach(function(value) {
+        t.test('input coerce to boolean (pass) - value ' + value, function (t) {
+            t.plan(2);
+
+            validator.make({
+                name: 'id',
+                required: true,
+                type: 'boolean'
+            }).validate(value, function (error, result) {
+                t.ok(!error, 'no error.');
+                t.equal(result, true);
+            });
         });
     });
 


### PR DESCRIPTION
`coercion()` method doesn't work with parameters of type boolean.
A string with value `'false'` was coerced to `true` because not empty strings are truthy.