### PR TITLE
Made `true` truthy

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -196,7 +196,7 @@ function coercion(parameter, consumes) {
             break;
         case 'boolean':
             fn = function(data) {
-                return (data === 'true') || (data === '1');
+                return (data === 'true') || (data === '1') || (data === true);
             };
             break;
         case 'date':

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -198,7 +198,7 @@ test('validation', function (t) {
         });
     });
 
-    ['false', '0'].forEach(function(value) {
+    ['false', '0', false].forEach(function(value) {
         t.test('input coerce to boolean (pass) - value ' + value, function (t) {
             t.plan(2);
 
@@ -213,7 +213,7 @@ test('validation', function (t) {
         });
     });
 
-    ['true', '1'].forEach(function(value) {
+    ['true', '1', true].forEach(function(value) {
         t.test('input coerce to boolean (pass) - value ' + value, function (t) {
             t.plan(2);
 


### PR DESCRIPTION
Fixes an issue where `true` is not truthy.

This issue arises when you're using
```yaml
  - name: someBool
    in: formData
    type: boolean
    default: false
```

If you send the data using JSON, `true` is taken as the value, and then is coerced to `false`. Test plan updated to validate.