### PR TITLE
bugfix(validator): switch from string to array of string

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -20,8 +20,11 @@ module.exports = function validator(options) {
                     required: true
                 },
                 consumes: {
-                    type: 'string',
-                    pattern: /multipart\/form-data|application\/x-www-form-urlencoded/,
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                        pattern: /multipart\/form-data|application\/x-www-form-urlencoded/,
+                    },
                     required: true
                 },
                 in: {

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -274,7 +274,7 @@ test('validation', function (t) {
         validator.make({
             name: 'upload',
             type: 'file'
-        }, 'multipart/form-data').validate('data', function (error) {
+        }, ['multipart/form-data']).validate('data', function (error) {
             t.ok(!error, 'no error.');
         });
     });
@@ -285,7 +285,7 @@ test('validation', function (t) {
         validator.make({
             name: 'upload',
             type: 'file'
-        }, 'application/json').validate('data', function (error) {
+        }, ['application/json']).validate('data', function (error) {
             t.ok(error, 'error.');
         });
     });


### PR DESCRIPTION
Update the `consumes` of file type to be array with items being a string with pattern.

closes #54 