### PR TITLE
update enjoi reference to v 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "caller": "^1.0.1",
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",
-    "enjoi": "^1.0.0",
+    "enjoi": "^1.0.2",
     "swagger-schema-official": "^2.0.0-"
   },
   "devDependencies": {


### PR DESCRIPTION
I updated the enjoi reference from version 1.0.0 to 1.0.2.

I was running into problems within the call to `validator:make()` in cases where the swagger spec contains $ref schemas on in-body parameters.

It's due to the _validator.js_ code expecting the 1.0.2 version enjoi constructor (which takes an `options` object), but the reference to enjoi 1.0.0 instead providing a constructor that takes a `subschemas` object.

https://github.com/Fanatics/swaggerize-routes/blob/master/lib/validator.js#L83

https://github.com/tlivings/enjoi/blob/401467bf7aef14352f29d713392ab694f2618d7a/lib/enjoi.js#L7