### PR TITLE
Fallback security to root api if missing in verb or path specification

### DIFF
--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -37,7 +37,7 @@ function buildroutes(options) {
                 name: operation.operationId,
                 description: operation.description,
                 method: verb,
-                security: buildSecurity(options.basedir, api.securityDefinitions, operation.security || def.security),
+                security: buildSecurity(options.basedir, api.securityDefinitions, operation.security || def.security || api.security),
                 validators: [],
                 handler : undefined,
                 consumes: operation.consumes || api.consumes,
@@ -151,8 +151,8 @@ function resolve(basedir, pathname, method) {
     var handler;
     try {
         //If the pathname is already a resolved function, return it.
-        //In the case of x-handler and x-authorize, users can define 
-        //external handler/authorize modules and functions OR override 
+        //In the case of x-handler and x-authorize, users can define
+        //external handler/authorize modules and functions OR override
         //existing x-authorize functions.
         if (thing.isFunction(pathname)) {
             return pathname;

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -38,14 +38,6 @@
                 "produces": [
                     "application/json"
                 ],
-                "security": [
-                    {
-                        "default": ["read"]
-                    },
-                    {
-                        "secondary": ["read"]
-                    }
-                ],
                 "jsonp": "callback",
                 "cache":{
                   "statuses":[200]

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -23,6 +23,11 @@
     "produces": [
         "application/json"
     ],
+    "security": [
+        {
+            "default": ["read"]
+        }
+    ],
     "paths": {
         "/pets": {
             "x-handler": "extensions/pets.js",
@@ -32,11 +37,6 @@
                 "x-handler": "extensions/pets.js",
                 "produces": [
                     "application/json"
-                ],
-                "security": [
-                    {
-                        "default": ["read"]
-                    }
                 ],
                 "jsonp": "callback",
                 "cache":{

--- a/test/test-routebuilder.js
+++ b/test/test-routebuilder.js
@@ -15,19 +15,19 @@ test('routebuilder', function (t) {
         t.strictEqual(routes.length, 4, 'added 4 routes.');
 
         routes.forEach(function (route) {
-            t.ok(route.hasOwnProperty('method'), 'has method property.');
-            t.ok(route.hasOwnProperty('description'), 'has validate property.');
-            t.ok(route.hasOwnProperty('name'), 'has name property.');
-            t.ok(route.hasOwnProperty('path'), 'has path property.');
-            t.ok(route.hasOwnProperty('security'), 'has security property.');
-            t.ok(route.hasOwnProperty('validators'), 'has before property.');
+            t.notEqual(route.method, 'has method property.');
+            t.notEqual(route.description, undefined, 'has validate property.');
+            t.notEqual(route.name, undefined, 'has name property.');
+            t.notEqual(route.path, undefined, 'has path property.');
+            t.notEqual(route.security, undefined, 'has security property.');
+            t.notEqual(route.validators, undefined, 'has before property.');
             if(route.method === 'get' && route.path === '/pets'){
               t.ok(route.jsonp === 'callback', 'options property is the right one.');
               t.ok(route.cache.statuses.join(',') === '200', 'options property is the right one.');
               t.ok(route.config.plugins.policies.join(', ') === 'isLoggedIn, addTracking, logThis', 'options property is the right one.');
             }
-            t.ok(route.hasOwnProperty('handler'), 'has handler property.');
-            t.ok(route.hasOwnProperty('produces'), 'has validate property.');
+            t.notEqual(route.handler, undefined, 'has handler property.');
+            t.notEqual(route.produces, undefined, 'has validate property.');
         });
 
         t.end();
@@ -39,14 +39,14 @@ test('routebuilder', function (t) {
         t.strictEqual(routes.length, 2, 'added 2 routes.');
 
         routes.forEach(function (route) {
-            t.ok(route.hasOwnProperty('method'), 'has method property.');
-            t.ok(route.hasOwnProperty('description'), 'has validate property.');
-            t.ok(route.hasOwnProperty('name'), 'has name property.');
-            t.ok(route.hasOwnProperty('path'), 'has path property.');
-            t.ok(route.hasOwnProperty('security'), 'has security property.');
-            t.ok(route.hasOwnProperty('validators'), 'has before property.');
-            t.ok(route.hasOwnProperty('handler'), 'has handler property.');
-            t.ok(route.hasOwnProperty('produces'), 'has validate property.');
+            t.notEqual(route.method, undefined, 'has method property.');
+            t.notEqual(route.description, undefined, 'has validate property.');
+            t.notEqual(route.name, undefined, 'has name property.');
+            t.notEqual(route.path, undefined, 'has path property.');
+            t.notEqual(route.security, undefined, 'has security property.');
+            t.notEqual(route.validators, undefined, 'has before property.');
+            t.notEqual(route.handler, undefined, 'has handler property.');
+            t.notEqual(route.produces, undefined, 'has validate property.');
         });
 
         t.end();
@@ -164,15 +164,15 @@ test('routebuilder', function (t) {
         t.strictEqual(routes.length, 2, 'added 1 routes.');
 
         routes.forEach(function (route) {
-            t.ok(route.hasOwnProperty('method'), 'has method property.');
-            t.ok(route.hasOwnProperty('description'), 'has validate property.');
-            t.ok(route.hasOwnProperty('name'), 'has name property.');
-            t.ok(route.hasOwnProperty('path'), 'has path property.');
-            t.ok(route.hasOwnProperty('security'), 'has security property.');
-            t.ok(route.hasOwnProperty('validators'), 'has validators property.');
-            t.ok(route.hasOwnProperty('handler'), 'has handler property.');
-            t.ok(route.hasOwnProperty('produces'), 'has produces property.');
-            t.ok(route.hasOwnProperty('consumes'), 'has consumes property.');
+            t.notEqual(route.method, undefined, 'has method property.');
+            t.equal(route.description, undefined, 'has no description property.');
+            t.notEqual(route.name, undefined, 'has name property.');
+            t.notEqual(route.path, undefined, 'has path property.');
+            t.equal(route.security, undefined, 'has no security property.');
+            t.notEqual(route.validators, undefined, 'has validators property.');
+            t.notEqual(route.handler, undefined, 'has handler property.');
+            t.notEqual(route.produces, undefined, 'has produces property.');
+            t.notEqual(route.consumes, undefined, 'has consumes property.');
         });
 
         t.end();


### PR DESCRIPTION
According to the swagger documentation, you can have a top-level security declaration that would be applied to all routes, but swaggerize-routes does not take that into consideration. 

It only inherits security from a path specification, if it hasn't been declared at a verb declaration.

I couldn't find any tests for the fallback on path, so I wasn't sure where I should add a fallback test for top-level security in this case.
