### PR TITLE
fix missing validators for referencing parameters

### DIFF
--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -48,19 +48,19 @@ function buildroutes(options) {
                 jsonp: operation.jsonp || api.jsonp
             };
 
-            validators = {};
-
-            if (def.parameters) {
-                def.parameters.forEach(function (parameter) {
-                    validators[parameter.in + parameter.name] = parameter;
-                });
-            }
-
-            if (operation.parameters) {
-                operation.parameters.forEach(function (parameter) {
-                    validators[parameter.in + parameter.name] = parameter;
-                });
-            }
+            validators = [].concat ( def.parameters || [], operation.parameters || [] );
+            // validators = {};
+            // if (def.parameters) {
+            //     def.parameters.forEach(function (parameter) {
+            //         validators[parameter.in + parameter.name] = parameter;
+            //     });
+            // }
+            //
+            // if (operation.parameters) {
+            //     operation.parameters.forEach(function (parameter) {
+            //         validators[parameter.in + parameter.name] = parameter;
+            //     });
+            // }
 
             route.validators = validator.makeAll(validators, route);
 

--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -49,19 +49,6 @@ function buildroutes(options) {
             };
 
             validators = [].concat ( def.parameters || [], operation.parameters || [] );
-            // validators = {};
-            // if (def.parameters) {
-            //     def.parameters.forEach(function (parameter) {
-            //         validators[parameter.in + parameter.name] = parameter;
-            //     });
-            // }
-            //
-            // if (operation.parameters) {
-            //     operation.parameters.forEach(function (parameter) {
-            //         validators[parameter.in + parameter.name] = parameter;
-            //     });
-            // }
-
             route.validators = validator.makeAll(validators, route);
 
             pathnames = [];

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -44,17 +44,22 @@ module.exports = function validator(options) {
 
     return {
         /**
-         * Creates a parameter validator.
+         * Creates all validators from given parameter array.
          * @param parameter
          * @returns {Function}
          */
         makeAll: function (validators, route) {
             var self = this;
-
-            return Object.keys(validators).map(function (k) {
+            var madeAll = {};
+            Object.keys(validators).forEach(function (k) {
                 var parameter = validators[k];
+                var made = self.make(parameter, route.consumes);
+                var key = made.parameter.in + made.parameter.name;
+                madeAll[key] = made;
+            });
 
-                return self.make(parameter, route.consumes);
+            return Object.keys(madeAll).map(function (k) {
+                return madeAll[k];
             });
         },
 
@@ -100,7 +105,7 @@ module.exports = function validator(options) {
             }
 
             if (parameter.in !== 'body' && parameter.allowEmptyValue){
-              schema = schema.allow('').optional();
+                schema = schema.allow('').optional();
             }
 
             return {

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -275,13 +275,74 @@
                     "format": "dateTime"
                 }
             ]
+        },
+        "/pets/{id}/items/{itemId}": {
+            "put": {
+                "description": "update some pet's item",
+                "operationId": "updatePetItem",
+                "x-handler": "extensions/items.js",
+                "produces": [
+                    "application/json"
+                ],
+                "security": [
+                    {
+                        "default": ["read"]
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "item",
+                        "in": "body",
+                        "description": "Item to add to the store",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Item"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "old item, before update",
+                        "schema": {
+                            "$ref": "#/definitions/Item"
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {"$ref": "#/parameters/id"},
+                {"$ref": "#/parameters/itemId"},
+                {
+                    "name": "date",
+                    "in": "header",
+                    "description": "Operation date",
+                    "required": false,
+                    "type": "string",
+                    "format": "dateTime"
+                }
+            ]
         }
+
     },
     "parameters": {
         "id": {
             "name": "id",
             "in": "path",
             "description": "Pet id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+        },
+        "itemId": {
+            "name": "itemId",
+            "in": "path",
+            "description": "Item id",
             "required": true,
             "type": "integer",
             "format": "int64"

--- a/test/fixtures/extensions/items.js
+++ b/test/fixtures/extensions/items.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function handler(req, res) {
+
+};

--- a/test/test-routebuilder.js
+++ b/test/test-routebuilder.js
@@ -12,7 +12,7 @@ test('routebuilder', function (t) {
     t.test('build directory', function (t) {
         routes = buildroutes({ api: api, basedir: path.join(__dirname, 'fixtures'), handlers: path.join(__dirname, 'fixtures/handlers')});
 
-        t.strictEqual(routes.length, 4, 'added 4 routes.');
+        t.strictEqual(routes.length, 5, 'added 5 routes.');
 
         routes.forEach(function (route) {
             t.ok(route.hasOwnProperty('method'), 'has method property.');
@@ -36,7 +36,7 @@ test('routebuilder', function (t) {
     t.test('build from x-handler', function (t) {
         routes = buildroutes({ api: api, basedir: path.join(__dirname, 'fixtures')});
 
-        t.strictEqual(routes.length, 2, 'added 2 routes.');
+        t.strictEqual(routes.length, 3, 'added 3 routes.');
 
         routes.forEach(function (route) {
             t.ok(route.hasOwnProperty('method'), 'has method property.');
@@ -73,7 +73,7 @@ test('routebuilder', function (t) {
             schemaValidator: schemaValidator
         });
 
-        t.strictEqual(routes.length, 6, 'added 6 routes.');
+        t.strictEqual(routes.length, 7, 'added 7 routes.');
 
         routes.forEach(function (route) {
             t.ok(route.hasOwnProperty('method'), 'has method property.');
@@ -119,12 +119,14 @@ test('routebuilder', function (t) {
     t.test('route validator merge', function(t) {
         var route;
         route = routes[5];
-
         t.strictEqual(route.validators.length, 3, 'has 3 validators.');
 
         var validator;
         validator = route.validators.filter(function (validator) {return validator.parameter.name === 'date'}).shift();
         t.ok(validator.parameter.required, 'override by operation.');
+
+        route = routes[6];
+        t.strictEqual(route.validators.length, 4, 'has 4 validators.');
 
         t.end();
     });

--- a/test/test-swaggerize.js
+++ b/test/test-swaggerize.js
@@ -43,7 +43,7 @@ test('configure', function (t) {
         });
 
         t.ok(thing.isArray(routes), 'returns array.');
-        t.strictEqual(routes.length, 4, 'routes.length 4.');
+        t.strictEqual(routes.length, 5, 'routes.length 5.');
     });
 
 });


### PR DESCRIPTION
fix to solve #40 
- moved merge logic into validators, removing temporal map in builder
- added testcase and fixed some tests for the added path in pets.json

If some parameters has only $ref without name or in, builder overwrites the parameters in raw object with same key, NaN (undefined + undefined). So, merging should be done after resolving references. 
