### PR TITLE
Fix route merge with multiple refs

### DIFF
--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -52,13 +52,21 @@ function buildroutes(options) {
 
             if (def.parameters) {
                 def.parameters.forEach(function (parameter) {
-                    validators[parameter.in + parameter.name] = parameter;
+                    if (parameter.$ref) {
+                        validators['$ref_' + parameter.$ref] = parameter;
+                    } else {
+                        validators[parameter.in + parameter.name] = parameter;
+                    }
                 });
             }
 
             if (operation.parameters) {
                 operation.parameters.forEach(function (parameter) {
-                    validators[parameter.in + parameter.name] = parameter;
+                    if (parameter.$ref) {
+                        validators['$ref_' + parameter.$ref] = parameter;
+                    } else {
+                        validators[parameter.in + parameter.name] = parameter;
+                    }
                 });
             }
 

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -63,12 +63,10 @@
                         "collectionFormat": "csv"
                     },
                     {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "maximum number of results to return",
-                        "required": false,
-                        "type": "integer",
-                        "format": "int32"
+                        "$ref": "#/parameters/limit"
+                    },
+                    {
+                        "$ref": "#/parameters/offset"
                     }
                 ],
                 "responses": {
@@ -291,6 +289,22 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+        },
+        "limit": {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+        },
+        "offset": {
+            "name": "offset",
+            "in": "query",
+            "description": "number of results to skip",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
         }
     },
     "securityDefinitions": {

--- a/test/test-routebuilder.js
+++ b/test/test-routebuilder.js
@@ -148,6 +148,14 @@ test('routebuilder', function (t) {
         t.end();
     });
 
+    t.test('route validator merge with multiple $ref', function(t) {
+        var route = routes[0]
+
+        t.strictEqual(route.validators.length, 3, 'has 3 validators');
+
+        t.end();
+    })
+
     t.test('bad dir', function (t) {
         t.plan(1);
 


### PR DESCRIPTION
I found a bug with the library where there are multiple parameters with $ref in route. In that case, only the validator for last parameter is used. I updated the test schema and added a simple test case. Please check this pull request for details.