### PR TITLE
To make the api more dynamic let's introduce defaulthandler

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -65,5 +65,5 @@
     "maxparams": 5,
     "maxdepth": 5,
     "maxstatements": 50,
-    "maxcomplexity": 15
+    "maxcomplexity": 16
 }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options:
 
 - `api` - a valid Swagger 2.0 object.
 - `handlers` - either a directory structure for route handlers or a premade object (see *Handlers Object* below).
+- `defaulthandler` - a handler function appropriate to the target framework, if used this will be the default handler for all generated routes (see *Default handler* below).
 - `basedir` - base directory to search for `handlers` path (defaults to `dirname` of caller).
 - `schemas` - an array of `{name: string, schema: string|object}` representing additional schemas to add to validation.
 - `security` - directory to scan for authorize handlers corresponding to `securityDefinitions`.
@@ -110,7 +111,7 @@ Or at the operation level:
 
 These paths are relative to the `options.basedir` and are used as fallbacks for missing handlers from directory scan.
 
-If the `options.handlers` is empty, then they will be used exclusively.
+If the `options.handlers` and `options.defaulthandler` is empty, then they will be used exclusively.
 
 ### Handlers File
 
@@ -161,6 +162,20 @@ Example:
 ```
 
 Handler keys in files do *not* have to be namespaced in this way.
+
+### Default handler
+
+The `options.defaulthandler` will set the handler function for all generated routes to one default handler.
+
+``` javascript
+var routes = builder({
+    api: require('./api.json'),
+    defaulthandler: function (req, reply) {
+       reply('something');
+    }
+});
+```
+
 
 ### Route Object
 

--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -13,10 +13,11 @@ var utils = require('./utils'),
  * @returns {Array}
  */
 function buildroutes(options) {
-    var api, routes, handlers, validator;
+    var api, routes, handlers, defaulthandler, validator;
 
     api = options.api;
     handlers = readhandlers(options.handlers);
+    defaulthandler = options.defaulthandler;
     validator = validation(options);
     routes = [];
 
@@ -39,7 +40,7 @@ function buildroutes(options) {
                 method: verb,
                 security: buildSecurity(options, api.securityDefinitions, operation.security || def.security),
                 validators: [],
-                handler : undefined,
+                handler : defaulthandler || undefined,
                 consumes: operation.consumes || api.consumes,
                 produces: operation.produces || api.produces,
                 json: operation.json || api.json,
@@ -73,14 +74,16 @@ function buildroutes(options) {
                 }
             });
 
-            route.handler = handlers && (pathnames[0] ? matchpath('$' + verb, pathnames, handlers[pathnames[0]]) : handlers['$' + verb]);
+            if (!route.handler) {
+                route.handler = handlers && (pathnames[0] ? matchpath('$' + verb, pathnames, handlers[pathnames[0]]) : handlers['$' + verb]);
+            }
 
             if (!route.handler) {
                 route.handler = operation['x-handler'] || def['x-handler'];
                 route.handler = route.handler && resolve(options.basedir, route.handler, verb);
             }
 
-            routes.push(route);
+            route.handler && routes.push(route);
         });
     });
 

--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -80,7 +80,7 @@ function buildroutes(options) {
                 route.handler = route.handler && resolve(options.basedir, route.handler, verb);
             }
 
-            route.handler && routes.push(route);
+            routes.push(route);
         });
     });
 

--- a/test/test-routebuilder.js
+++ b/test/test-routebuilder.js
@@ -109,6 +109,31 @@ test('routebuilder', function (t) {
         t.end();
     });
 
+    t.test('build with defaulthandler', function (t) {
+        routes = buildroutes({
+            api: api,
+            basedir: path.join(__dirname, 'fixtures'),
+            defaulthandler: function () {},
+            schemaValidator: schemaValidator
+        });
+
+        t.strictEqual(routes.length, 6, 'added 6 routes.');
+
+        routes.forEach(function (route) {
+            t.ok(route.hasOwnProperty('method'), 'has method property.');
+            t.ok(route.hasOwnProperty('description'), 'has validate property.');
+            t.ok(route.hasOwnProperty('name'), 'has name property.');
+            t.ok(route.hasOwnProperty('path'), 'has path property.');
+            t.ok(route.hasOwnProperty('security'), 'has security property.');
+            t.ok(route.hasOwnProperty('validators'), 'has validators property.');
+            t.ok(route.hasOwnProperty('handler'), 'has handler property.');
+            t.ok(route.hasOwnProperty('produces'), 'has produces property.');
+            t.ok(route.hasOwnProperty('consumes'), 'has consumes property.');
+        });
+
+        t.end();
+    });
+
     t.test('route validators', function (t) {
         var route;
 


### PR DESCRIPTION
In our project we don't use the file mappings for the handlers but we use this module for generating the base of the route and then in a later stage add a default handler for all the routes. This is because we have our handlers refers to a js file that handles the logic for the different routes.

This PR integrates this functionality directly in swaggerize-routes which is very useful if you just want one handler for all routes.

Example:

```
var builder = require('swaggerize-routes');

var routes = builder({
    api: require('./api.json'),
    defaulthandler: function (req, reply) {
       reply.('something');
    },
    security: './security' //Optional - security authorize handlers as per `securityDefinitions`
});
```
