### PR TITLE
Consider number types on coercion

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -185,6 +185,7 @@ function coercion(parameter, consumes) {
         case 'integer':
         case 'float':
         case 'long':
+        case 'number':
         case 'double':
             fn = function (data) {
                 if (isNaN(data)) {

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -142,6 +142,21 @@ test('validation', function (t) {
         });
     });
 
+    ['0', '1'].forEach(function(value) {
+        t.test('input coerce to number (pass) - value ' + value, function (t) {
+            t.plan(2);
+
+            validator.make({
+                name: 'id',
+                required: true,
+                type: 'number'
+            }).validate(value, function (error, result) {
+                t.ok(!error, 'no error.');
+                t.ok(thing.isNumber(result), 'coerced to number.');
+            });
+        });
+    });
+
     t.test('input coerce to byte (pass)', function (t) {
         t.plan(1);
 


### PR DESCRIPTION
Currently if a string parameter is validated against a schema specifying it as 'number', it would not be coerced.

When validating the input string '0', the result from validation (the number 0) would be taken as a "falsy" value and the original string '0' would be returned.

So, the type 'number', which is part of the Swagger specification was added to the cases to consider on coercion to avoid this behavior.