### PR TITLE
FIX Issue#76 Adding minLength attribute in validator's template

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -79,7 +79,8 @@ module.exports = function validator(options) {
                 schema: parameter.schema,
                 items: parameter.items,
                 properties: parameter.properties,
-                pattern: parameter.pattern
+                pattern: parameter.pattern,
+	        minLength: parameter.minLength
             };
 
             if ((parameter.in === 'body' || parameter.in === 'formData') && template.schema) {

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -275,7 +275,8 @@
                     "description": "Operation date",
                     "required": false,
                     "type": "string",
-                    "format": "dateTime"
+                    "format": "dateTime",
+		    "minLength": 5
                 }
             ]
         }

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -32,6 +32,25 @@ test('validation', function (t) {
         });
     });
 
+    t.test('input pass with minLength', function (t) {
+        t.plan(2);
+
+        var functionnalValidator = validator.make({
+            name: 'id',
+            required: true,
+            type: 'string',
+	    minLength: 2
+	});
+
+        functionnalValidator.validate('1', function (error) {
+            t.ok(error, 'error.');
+        });
+
+        functionnalValidator.validate('12', function (error) {
+            t.ok(!error, 'no error.');
+        });
+    });
+
     t.test('input pass with pattern', function (t) {
         t.plan(2);
 
@@ -283,7 +302,7 @@ test('validation', function (t) {
 
         v.validate({ id: 1, name: 'fluffy', extra: 'foo'}, function(error, result) {
             t.ok(!error, 'no error.');
-            t.ok(!result.extra, 'No extra properties')
+            t.ok(!result.extra, 'No extra properties');
         });
     });
 


### PR DESCRIPTION
Adding minLength attribute in the validator's template so that swagger
minLength attributes aren't ignored and overrided by enjoi which sets
minLength to 0.

Adding it in the template allows to reject shema that have parameters
that doesn't satisfies size constraint