### PR TITLE
Ensure referenced parameters are also validated

### DIFF
--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -53,12 +53,18 @@ function buildroutes(options) {
 
             if (def.parameters) {
                 def.parameters.forEach(function (parameter) {
+                    if (parameter.$ref) {
+                        parameter = validator.refresolve(parameter.$ref);
+                    }
                     validators[parameter.in + parameter.name] = parameter;
                 });
             }
 
             if (operation.parameters) {
                 operation.parameters.forEach(function (parameter) {
+                    if (parameter.$ref) {
+                        parameter = validator.refresolve(parameter.$ref);
+                    }
                     validators[parameter.in + parameter.name] = parameter;
                 });
             }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -44,6 +44,15 @@ module.exports = function validator(options) {
 
     return {
         /**
+         * Get the object the path references.
+         * @param value
+         * @returns {*}
+         */
+        refresolve: function(value) {
+            return refresolver(schemas, value);
+        },
+
+        /**
          * Creates a parameter validator.
          * @param parameter
          * @returns {Function}


### PR DESCRIPTION
In swaggerize-express, I found that validation is not performed (enums, lengths, required fields) on parameters that are referenced ($ref) in a path (instead of inline).  The updated code ensures that referenced params are pulled into the validator array.