### PR TITLE
prevent to overwrite handlers when handler is created already

### DIFF
--- a/lib/readhandlers.js
+++ b/lib/readhandlers.js
@@ -39,7 +39,7 @@ function read(dir) {
                 }
             }
             if (stat.isDirectory()) {
-                handlers[key] = read(abspath);
+                handlers[key] = Object.assign(handlers[key] || {} ,read(abspath));
             }
         });
 


### PR DESCRIPTION
A result of `fs.readdirSync(dir)` is important because it could create error when the order of directory name precede filename.

for example, let's assume that there is two files. 
handlers/users.js
handlers/users/{userId}.js
Normally the result of `fs.readdirSync(dir)`  will be ['users.js', 'users']. it works fine.
However, when the result of `fs.readdirSync(dir)`  is  [ 'users', 'users.js']. it makes error. it will overwrite users.js's handler.

I faced this situation when I tried to use pkg(https://github.com/zeit/pkg) for my project using swaggerize-hapi

I read the api document for fs.readdirSync, I cannot found the order of the result fixed.

I think the code requesting pull request prevent that kind of possible error situation.

Thanks!

