### PR TITLE
defaulthandler in options of v2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ builder({
         - A promise (or a `thenable`) that resolves to the swagger api Object.
 
     - `handlers` - (*Object*) or (*String*) - (required) - either a directory structure for route handlers or a pre-created object (see *Handlers Object* below). If `handlers` option is not provided, route builder will try to use the default `handlers` directory (only if it exists). If there is no `handlers` directory available, then the route builder will try to use the `x-handler` swagger schema extension.
+    - `defaulthandler` - (*Function*) - (optional) - default fallback handler if no other handler was provided.
     - `basedir` - (*String*) - (optional) - base directory to search for `handlers` path (defaults to `dirname` of caller).
     - `security` - (*String*) - (optional) - directory to scan for authorize handlers corresponding to `securityDefinitions`.
     - `validated` -  (*Boolean*) - (optional) - Set this property to `true` if the api is already validated against swagger schema and already dereferenced all the `$ref`. This is really useful to generate validators for parsed api specs. Default value for this is `false` and the api will be validated using [swagger-parser validate](https://github.com/BigstickCarpet/swagger-parser/blob/master/docs/swagger-parser.md#validateapi-options-callback).

--- a/lib/builders/routes.js
+++ b/lib/builders/routes.js
@@ -5,7 +5,7 @@ const buildSecurity = require('./security');
 const buildValidator = require('swagvali');
 
 const Buildroutes = (apiResolver, options) => {
-    let { handlers, basedir } = options;
+    let { handlers, basedir, defaulthandler } = options;
     let fileResolver = Thing.isObject(handlers)
         // Use the handlers object
         ? Promise.resolve(handlers)
@@ -34,6 +34,10 @@ const Buildroutes = (apiResolver, options) => {
                     if (handler) {
                         handler = Utils.resolve(basedir, handler, operation);
                     }
+                }
+                //Use default handler if no other handler defined
+                if (!handler) {
+                    handler = defaulthandler;
                 }
                 //Push the handler to the route definition.
                 if (handler){

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const Fs = require('fs');
 const Assert = require('assert');
 const Thing = require('core-util-is');
-const { isString, isObject } = Thing;
+const { isString, isObject, isFunction } = Thing;
 const Path = require('path');
 const Caller = require('caller');
 const Parser = require('swagger-parser');
@@ -10,7 +10,7 @@ const Buildroutes = require('./builders/routes');
 
 const Swaggerize = ( options = {}, callback) => {
     let routeObj;
-    let { api, validated, basedir, handlers } = options;
+    let { api, validated, basedir, handlers, defaulthandler } = options;
     //api should be a valid string path or an object
     Assert.ok(isString(api) || isObject(api), 'Expected an api definition.');
     // if basedir is truthy, it should be a valid option.
@@ -37,6 +37,10 @@ const Swaggerize = ( options = {}, callback) => {
     if (Thing.isString(handlers) && Path.resolve(handlers) !== handlers) {
         // Relative path, so resolve to basedir
         handlers = Path.join(basedir, handlers);
+    }
+    //defaulthandler should be a function if given
+    if (defaulthandler) {
+        Assert.ok(isFunction(defaulthandler), 'Expected defaulthandler to be a function.');
     }
     //If the api is not yet validated, do it here
     routeObj = Buildroutes((!validated) ? Parser.validate(api) : Promise.resolve(api), Object.assign({}, options, { basedir, handlers }));


### PR DESCRIPTION
Add an option for a  default (fallback) handler to be used if no other handler was found or given:
- Default handler is optional.
- Handler must be a function.
- Default handler is a fallback and is called only if handlers (object or files) doesn't have the right handler.

NOTE 1: in version 1.x there was an option with the same name which was used not as a fallback. It was always used for all paths and methods - making it quite useless.
The new option use case might be a 501 "not implemented" error (instead of 404 we have today) or any other default behaviour.

NOTE 2: I only made the code changes. If you approve the change, I will update the readme doc as well with explanations and samples.
