### PR TITLE
Do not suppress errors from requiering handler

### DIFF
--- a/lib/buildroutes.js
+++ b/lib/buildroutes.js
@@ -160,28 +160,26 @@ function buildSecurity(options, securityDefinitions, routeSecurity) {
  */
 function resolve(basedir, pathname, method) {
     var handler;
-    try {
-        //If the pathname is already a resolved function, return it.
-        //In the case of x-handler and x-authorize, users can define
-        //external handler/authorize modules and functions OR override
-        //existing x-authorize functions.
-        if (thing.isFunction(pathname)) {
-            return pathname;
-        }
-
-        pathname = path.resolve(basedir, pathname);
-        handler = require(pathname);
-
-        if (thing.isFunction(handler)) {
-            return handler;
-        }
-
-        return method && handler[method];
+    //If the pathname is already a resolved function, return it.
+    //In the case of x-handler and x-authorize, users can define
+    //external handler/authorize modules and functions OR override
+    //existing x-authorize functions.
+    if (thing.isFunction(pathname)) {
+        return pathname;
     }
-    catch (error) {
+    try {
+        pathname = path.resolve(basedir, pathname);
+    } catch (error) {
         utils.debuglog('Could not find %s.', pathname);
         return;
     }
+    handler = require(pathname);
+
+    if (thing.isFunction(handler)) {
+        return handler;
+    }
+
+    return method && handler[method];
 }
 
 module.exports = buildroutes;


### PR DESCRIPTION
Errors thrown by `require(pathname)` were previously caught
and suppressed here with a wrong messsage to debuglog.
Since this is also the code that includes security middlewares,
errors should be thrown.