### PR TITLE
Update to enjoi 3.x depdendency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "caller": "^1.0.1",
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",
-    "enjoi": "^3.0.0",
+    "enjoi": "^4.0.0",
     "swagger-schema-official": "^2.0.0-"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "caller": "^1.0.1",
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",
-    "enjoi": "^1.0.0",
+    "enjoi": "^3.0.0",
     "swagger-schema-official": "^2.0.0-"
   },
   "devDependencies": {


### PR DESCRIPTION
This resolves the vulnerability problem listed here: https://github.com/krakenjs/swaggerize-routes/issues/94
The fix from @iamjoeker only resolves the problem with the enjoi itself while swaggerize-routes still uses the 1.x version of enjoi which has the downstream dependency problem.